### PR TITLE
Fix misplaced \q tags

### DIFF
--- a/19-PSA/119.usfm
+++ b/19-PSA/119.usfm
@@ -150,8 +150,7 @@
 
 \s5
 \q
-\v 35
-Guide me in the path of your commandments,
+\v 35 Guide me in the path of your commandments,
 \q for I delight to walk in it.
 \q
 \v 36 Direct my heart toward your covenant decrees

--- a/27-DAN/04.usfm
+++ b/27-DAN/04.usfm
@@ -5,8 +5,8 @@
 \p
 \v 1 King Nebuchadnezzar sent this decree to all peoples, nations, and languages who lived on the earth: "May your peace increase.
 \v 2 It has seemed good to me to tell you about the signs and wonders that the Most High has done for me.
-\v 3
-\q How great are his signs,
+\q
+\v 3 How great are his signs,
 \q and how mighty are his wonders!
 \q His kingdom is an everlasting kingdom,
 \q and his dominion lasts from generation to generation."

--- a/47-1CO/02.usfm
+++ b/47-1CO/02.usfm
@@ -36,6 +36,6 @@
 \s5
 \v 14 The unspiritual person does not receive the things that belong to the Spirit of God, for they are foolishness to him. He cannot know them because they are spiritually discerned.
 \v 15 The one who is spiritual judges all things, but he is not subject to the judgment of others.
-\v 16
-\q "For who can know the mind of the Lord, that he can instruct him?"
+\q
+\v 16 "For who can know the mind of the Lord, that he can instruct him?"
 \m But we have the mind of Christ.


### PR DESCRIPTION
The `\v #` tag must be followed by verse text on the same line